### PR TITLE
Fix tests compatibility with newer Rust versions

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
+        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError"
     )]
     fn nanos_to_duration_overflow() {
         let _ = nanos_to_duration(Duration::MAX.as_nanos() + 1);
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
+        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError"
     )]
     #[allow(clippy::arithmetic_side_effects)]
     fn nanos_to_duration_overflow_manual() {


### PR DESCRIPTION
`TryFromIntError` now has more information, so this changes the test to
just look for the name of the error, which should be compatible with
both old and new Rust versions.
